### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ example.rb
 Change thresholds to show as:
 
 ```ruby
-LineProf.report(profile, threshods: {
+LineProf.report(profile, thresholds: {
   LineProf::CRITICAL => 1000, # default:  50 (ms)
   LineProf::WARNING  =>  100, # default:   5 (ms)
   LineProf::NOMINAL  =>   10, # default: 0.2 (ms)


### PR DESCRIPTION
Fixing a typo in README. 

https://github.com/sonots/rblineprof-report/blob/81c7a9c9b7f25034fa7ffb55037fd2ba3cd93baf/lib/rblineprof/report/source.rb#L83

(Thanks for writing this gem! It is really handy.)